### PR TITLE
fix: Ensure tutorial overlay does not block UI interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,11 +41,11 @@
         .tutorial-skip-btn { position: fixed; bottom: 30px; right: 30px; background: rgba(255, 255, 255, 0.1); backdrop-filter: blur(10px); border: 1px solid rgba(255, 255, 255, 0.2); color: rgba(255, 255, 255, 0.7); padding: 8px 16px; border-radius: 20px; font-size: 12px; font-weight: 600; cursor: pointer; pointer-events: auto; transition: all 0.2s; text-transform: uppercase; letter-spacing: 0.05em; z-index: 10003; }
         .tutorial-skip-btn:hover { background: rgba(255, 255, 255, 0.2); color: white; transform: scale(1.05); }
 
-        .tutorial-blob { position: absolute; width: 140px; transition: all 0.5s ease-out; z-index: 10001; }
+        .tutorial-blob { position: absolute; width: 140px; transition: all 0.5s ease-out; z-index: 10001; pointer-events: none; }
         /* Soft Yellow color #fef08a (similar to sticky note/Whisk) */
         .tutorial-blob svg path { fill: #fef08a; stroke: rgba(0,0,0,0.1); stroke-width: 1px; }
         .tutorial-blob svg { width: 100%; height: auto; filter: drop-shadow(0px 8px 24px rgba(0,0,0,0.15)); }
-        .tutorial-text { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; text-align: center; padding: 25px; font-family: 'Patrick Hand', cursive; font-size: 16px; line-height: 1.3; color: #18181b; font-weight: 600; transform: rotate(-2deg); }
+        .tutorial-text { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; text-align: center; padding: 25px; font-family: 'Patrick Hand', cursive; font-size: 16px; line-height: 1.3; color: #18181b; font-weight: 600; transform: rotate(-2deg); pointer-events: none; }
 
         .tutorial-arrow { position: absolute; width: 60px; height: 60px; transition: all 0.5s ease-out; z-index: 10000; }
         .tutorial-arrow svg { width: 100%; height: 100%; filter: drop-shadow(2px 2px 0px rgba(0,0,0,0.1)); }
@@ -197,7 +197,7 @@
                 this.isActive = true;
                 document.body.classList.add('tutorial-active');
                 this.skipBtn.innerText = "Skip Tutorial";
-                this.overlay.style.pointerEvents = 'auto'; // Enable clicks for skip button
+                // this.overlay.style.pointerEvents = 'auto'; // REMOVED: Overlay must be passthrough
                 this.showStep(0);
             }
 


### PR DESCRIPTION
- Remove `pointer-events: auto` from JS `TutorialManager.start()`.
- Add `pointer-events: none` to CSS for `.tutorial-blob` and `.tutorial-text`.
- Ensure users can click on labels and inputs underneath the tutorial bubbles.
- Retain interactivity for "Skip Tutorial" button by keeping it outside the overlay container.