### PR TITLE
Fix: Ensure 3D label edits advance the tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@
             const sortedZ = [-w/2, ...[...dividersZ].sort((a,b) => a-b), w/2];
             for(let i=0; i < sortedZ.length - 1; i++) { const dist = sortedZ[i+1] - sortedZ[i]; if(dist < 1) continue; const el = createEditableLabel(Math.round(dist), (nd) => { const diff = nd - dist; for(let k=0; k<dividersZ.length; k++) if(dividersZ[k] >= sortedZ[i+1] - 0.1) dividersZ[k] += diff; }); el.style.left = `${w2pX(-l/2) - 35}px`; el.style.top = `${w2pZ((sortedZ[i] + sortedZ[i+1]) / 2)}px`; el.style.transform = 'translateY(-50%)'; dimContainer.appendChild(el); }
             const labels3D = [ { text: Math.round(l), pos: new THREE.Vector3(0, -h/2 - 10, w/2 + 10), target: 'dim-l' }, { text: Math.round(w), pos: new THREE.Vector3(l/2 + 15, -h/2 - 10, 0), target: 'dim-w' }, { text: Math.round(h), pos: new THREE.Vector3(-l/2 - 15, 0, w/2 + 15), target: 'dim-h' } ];
-            labels3D.forEach(info => { const el = createEditableLabel(info.text, (nv) => { document.getElementById(info.target).value = nv; checkAutoZoom(); }); el.classList.add('dim-label-3d'); el.dataset.worldPos = JSON.stringify(info.pos); dimContainer3D.appendChild(el); });
+            labels3D.forEach((info, index) => { const el = createEditableLabel(info.text, (nv) => { document.getElementById(info.target).value = nv; checkAutoZoom(); setTimeout(() => tutorial.advanceFrom(index), 100); }); el.classList.add('dim-label-3d'); el.dataset.worldPos = JSON.stringify(info.pos); dimContainer3D.appendChild(el); });
             document.getElementById('divider-stats').innerText = `Vert: ${dividersX.length} | Horiz: ${dividersZ.length}`;
         }
 


### PR DESCRIPTION
Modified `createEditableLabel` callbacks for 3D view labels in `index.html`. Added a `setTimeout` to call `tutorial.advanceFrom(index)` after updating dimensions. This ensures the tutorial advances correctly when users edit dimensions via the 3D view labels, not just the bottom panel. The timeout handles the race condition where `updateBox` re-renders labels, ensuring the tutorial points to the new DOM elements.