### PR TITLE
Fix tutorial bubble layering: Step 2.2 overlaps config panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
                 this.step = 0;
                 this.isActive = false;
                 this.overlay = document.getElementById('tutorial-overlay');
+                this.underlay = document.getElementById('tutorial-underlay');
                 this.blob = document.getElementById('tut-blob');
                 this.text = document.getElementById('tut-text');
                 this.arrow = document.getElementById('tut-arrow');
@@ -222,6 +223,11 @@
                 this.ghostDivider.style.opacity = 0;
                 this.ghostDivider.style.animation = 'none';
                 this.cursorTrail.style.opacity = 0;
+
+                // Adjust Z-Index: Step 4 (Add Vertical) needs to overlap the config panel (z-10)
+                if (this.underlay) {
+                    this.underlay.style.zIndex = (stepIndex === 4) ? '50' : '5';
+                }
 
                 // Reset cursor icon to pointer
                 this.cursor.innerHTML = '<svg viewBox="0 0 24 24" fill="white" stroke="black" stroke-width="2" xmlns="http://www.w3.org/2000/svg"><path d="M3 3L10.07 19.97L12.58 12.58L19.97 10.07L3 3Z" /></svg>';

--- a/verification/verify_z_index.py
+++ b/verification/verify_z_index.py
@@ -1,0 +1,57 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def verify_z_index():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        # Load the page
+        await page.goto("http://localhost:8000")
+
+        # Helper to get z-index
+        async def get_z_index():
+            return await page.eval_on_selector("#tutorial-underlay", "el => window.getComputedStyle(el).zIndex")
+
+        # Step 0: Initial State
+        print("Checking Step 0...")
+        z_index_0 = await get_z_index()
+        print(f"Step 0 Z-Index: {z_index_0}")
+        if z_index_0 != "5":
+            print("FAILURE: Step 0 z-index should be 5")
+            await browser.close()
+            return
+
+        # Advance to Step 4
+        # We can cheat by calling tutorial.showStep(4) directly via console for speed
+        print("Advancing to Step 4...")
+        await page.evaluate("tutorial.showStep(4)")
+
+        # Allow a brief moment for any potential updates (though this one is synchronous DOM update)
+        await asyncio.sleep(0.1)
+
+        # Step 4: Vertical Divider
+        z_index_4 = await get_z_index()
+        print(f"Step 4 Z-Index: {z_index_4}")
+        if z_index_4 != "50":
+            print("FAILURE: Step 4 z-index should be 50")
+            await browser.close()
+            return
+
+        # Go back to Step 3 or 0 to verify reset
+        print("Returning to Step 0...")
+        await page.evaluate("tutorial.showStep(0)")
+        await asyncio.sleep(0.1)
+
+        z_index_back = await get_z_index()
+        print(f"Step 0 (Again) Z-Index: {z_index_back}")
+        if z_index_back != "5":
+             print("FAILURE: Reset to z-index 5 failed")
+             await browser.close()
+             return
+
+        print("SUCCESS: Z-Index logic verified correctly.")
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(verify_z_index())


### PR DESCRIPTION
Adjusted the `TutorialManager` to use a separate `#tutorial-underlay` for background bubbles. Implemented dynamic z-index switching:
- Default `z-index: 5` keeps bubbles behind dimension labels (Steps 0-2).
- `z-index: 50` is applied specifically for Step 4 ("Add Vertical") to ensure the bubble renders on top of the bottom configuration panel (z-10).

Verified via Playwright script ensuring correct z-index values per step.