### PR TITLE
Ensure tutorial bubbles overlay UI for both divider steps (3 and 4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,9 +224,9 @@
                 this.ghostDivider.style.animation = 'none';
                 this.cursorTrail.style.opacity = 0;
 
-                // Adjust Z-Index: Step 4 (Add Vertical) needs to overlap the config panel (z-10)
+                // Adjust Z-Index: Steps 3 (Horizontal) & 4 (Vertical) need to overlap UI elements (z-10)
                 if (this.underlay) {
-                    this.underlay.style.zIndex = (stepIndex === 4) ? '50' : '5';
+                    this.underlay.style.zIndex = (stepIndex === 3 || stepIndex === 4) ? '50' : '5';
                 }
 
                 // Reset cursor icon to pointer

--- a/verification/verify_z_index.py
+++ b/verification/verify_z_index.py
@@ -22,15 +22,23 @@ async def verify_z_index():
             await browser.close()
             return
 
-        # Advance to Step 4
-        # We can cheat by calling tutorial.showStep(4) directly via console for speed
-        print("Advancing to Step 4...")
-        await page.evaluate("tutorial.showStep(4)")
-
-        # Allow a brief moment for any potential updates (though this one is synchronous DOM update)
+        # Advance to Step 3
+        print("Advancing to Step 3...")
+        await page.evaluate("tutorial.showStep(3)")
         await asyncio.sleep(0.1)
 
-        # Step 4: Vertical Divider
+        z_index_3 = await get_z_index()
+        print(f"Step 3 Z-Index: {z_index_3}")
+        if z_index_3 != "50":
+            print("FAILURE: Step 3 z-index should be 50")
+            await browser.close()
+            return
+
+        # Advance to Step 4
+        print("Advancing to Step 4...")
+        await page.evaluate("tutorial.showStep(4)")
+        await asyncio.sleep(0.1)
+
         z_index_4 = await get_z_index()
         print(f"Step 4 Z-Index: {z_index_4}")
         if z_index_4 != "50":
@@ -38,7 +46,7 @@ async def verify_z_index():
             await browser.close()
             return
 
-        # Go back to Step 3 or 0 to verify reset
+        # Go back to Step 0 to verify reset
         print("Returning to Step 0...")
         await page.evaluate("tutorial.showStep(0)")
         await asyncio.sleep(0.1)
@@ -50,7 +58,7 @@ async def verify_z_index():
              await browser.close()
              return
 
-        print("SUCCESS: Z-Index logic verified correctly.")
+        print("SUCCESS: Z-Index logic verified correctly for Steps 3 and 4.")
         await browser.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updated `TutorialManager.showStep` to apply `z-index: 50` to the tutorial underlay for both Step 3 (Add Horizontal) and Step 4 (Add Vertical). This ensures the bubbles appear on top of the configuration panel.

- Verified via `verification/verify_z_index.py` that steps 3 and 4 use z-50, while others remain at z-5.