### PR TITLE
Fix divider deletion logic and improve edge interaction

### DIFF
--- a/src/features/DividerSystem.js
+++ b/src/features/DividerSystem.js
@@ -311,6 +311,19 @@ export class DividerSystem {
                     else if (segIdx > removedSpatialIdx + 1) newHidden[`${axis}_${lineIdx}_${segIdx - 1}`] = true;
                 }
             }
+
+            // Check for merged segments that should remain hidden
+            const crossAxis = removedAxis === 'X' ? 'Z' : 'X';
+            const crossDividers = removedAxis === 'X' ? dZ : dX;
+
+            for (let i = 0; i < crossDividers.length; i++) {
+                const k1 = `${crossAxis}_${i}_${removedSpatialIdx}`;
+                const k2 = `${crossAxis}_${i}_${removedSpatialIdx + 1}`;
+                if (hidden[k1] && hidden[k2]) {
+                    newHidden[`${crossAxis}_${i}_${removedSpatialIdx}`] = true;
+                }
+            }
+
             return newHidden;
         };
 


### PR DESCRIPTION
- Fix a bug where removing a divider caused previously deleted segments of perpendicular dividers to reappear. Merged segments now correctly inherit the hidden state if both original segments were hidden.
- Reduce dead zones for divider placement near box edges (5mm -> 2mm).
- Refine hit detection margin for divider snapping (35px -> 25px).

Fixed: "Deletes incorrectly leading to geometry errors" when removing dividers with complex hidden segment states.
Fixed: Unable to place dividers close to the walls.