### PR TITLE
Fix geometry artifacts for donut-shaped rooms and duplicate dividers

### DIFF
--- a/src/utils/GeometryFactory.js
+++ b/src/utils/GeometryFactory.js
@@ -314,6 +314,11 @@ export function createModel(l, h, w, r, dX, dZ, hiddenSegments = {}, colorTheme 
         const holeShape = traceRoomBoundary(room.cells, sortedX, sortedZ, thick, l, w, r);
         if (holeShape) {
             outerShape.holes.push(holeShape);
+
+            // Flatten nested holes (islands) so they are respected by ExtrudeGeometry
+            if (holeShape.holes && holeShape.holes.length > 0) {
+                holeShape.holes.forEach(h => outerShape.holes.push(h));
+            }
         }
     });
 


### PR DESCRIPTION
- Support holes in geometry generation:
  - Updated `src/utils/GeometryFactory.js` to correctly handle multiple loops found during boundary tracing.
  - The largest loop (by area) is now treated as the outer shape, while smaller loops are added as holes.
  - Added logic to flatten nested holes (islands) when adding room shapes to the main tray shape. This ensures `THREE.ExtrudeGeometry` respects islands (like the center of a donut room), keeping them solid instead of creating a filled void.
- Prevent duplicate dividers:
  - Updated `src/core/Store.js` to enforce a minimum distance (0.1 units) between dividers, preventing the creation of zero-width cells.
  - Updated `src/utils/GeometryFactory.js` to filter out zero-length edges (epsilon 0.0001) which caused invalid loops.