### PR TITLE
Fix tutorial drag step visual guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,18 @@
             90% { transform: translate(-50%, -50%) scale(1); }
             100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
         }
+
+        @keyframes cursor-wiggle-x {
+            0% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+            10% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+            20% { transform: translate(-50%, -50%) scale(0.9); }
+            35% { transform: translate(calc(-50% - 40px), -50%) scale(0.9); }
+            50% { transform: translate(calc(-50% + 40px), -50%) scale(0.9); }
+            65% { transform: translate(calc(-50% - 40px), -50%) scale(0.9); }
+            80% { transform: translate(-50%, -50%) scale(0.9); }
+            90% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+            100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+        }
     </style>
 </head>
 <body class="relative h-screen w-screen">

--- a/src/features/TutorialSystem.js
+++ b/src/features/TutorialSystem.js
@@ -219,11 +219,12 @@ export class TutorialSystem {
                                 y: coords.y
                             }),
                             tagName: 'DIV',
-                            id: 'virtual-divider-target'
+                            id: 'virtual-divider-target',
+                            classList: { contains: () => false }
                         };
                     }
                 }
-                this.positionHint(dragTarget, 'Click & Hold to move', 'bottom');
+                this.positionHint(dragTarget, 'Drag to move divider', 'bottom');
                 this.playDragAnimation(dragTarget);
                 break;
             case 6: // Delete
@@ -327,15 +328,17 @@ export class TutorialSystem {
 
         this.cursor.style.left = `${startX}px`;
         this.cursor.style.top = `${startY}px`;
-        this.cursor.innerHTML = '<svg viewBox="0 0 24 24" fill="white" stroke="black" stroke-width="2" xmlns="http://www.w3.org/2000/svg"><path d="M18 11V6a2 2 0 0 0-2-2 2 2 0 0 0-2 2v1h-1V4a2 2 0 0 0-2-2 2 2 0 0 0-2 2v3h-1V2a2 2 0 0 0-2-2 2 2 0 0 0-2 2v5h-1V5a2 2 0 0 0-2-2 2 2 0 0 0-2 2v6c0 4.418 3.582 8 8 8s8-3.582 8-8z" /></svg>';
-        this.cursor.style.animation = 'cursor-drag-shadow 4s infinite';
+        // Grab/Fist Icon
+        this.cursor.innerHTML = '<svg viewBox="0 0 24 24" fill="white" stroke="black" stroke-width="2" xmlns="http://www.w3.org/2000/svg"><path d="M20 10.95V7c0-1.1-.9-2-2-2s-2 .9-2 2v2.5h-1V5c0-1.1-.9-2-2-2s-2 .9-2 2v4.5h-1V6c0-1.1-.9-2-2-2s-2 .9-2 2v7.5c0 3.31 2.69 6 6 6s6-2.69 6-6z" /></svg>';
+        this.cursor.style.animation = 'cursor-wiggle-x 4s infinite';
 
         this.ghostDivider.style.left = `${startX}px`;
         this.ghostDivider.style.top = `${startY}px`;
         this.ghostDivider.style.width = '100px';
         this.ghostDivider.style.height = '4px';
         this.ghostDivider.style.opacity = 0;
-        this.ghostDivider.style.animation = 'divider-drag-shadow 4s infinite';
+        // Also wiggle the ghost divider to match cursor
+        this.ghostDivider.style.animation = 'cursor-wiggle-x 4s infinite';
     }
 
     playDeleteAnimation(target) {


### PR DESCRIPTION
This PR addresses the missing 'grab and move' instruction in the onboarding tutorial (Step 5). 

Changes include:
- **Visuals:** Replaced the generic cursor with a 'Grabbing Hand' icon and added a side-to-side 'wiggle' animation to demonstrate the dragging action.
- **Text:** Updated the hint text to 'Drag to move divider'.
- **Bug Fix:** Fixed a Javascript error in `TutorialSystem.js` where the mock target element for the divider lacked a `classList` property, causing the tutorial step to crash before the animation could play.

Verified using Playwright screenshot testing to ensure the icon appears correctly over the target divider.

---
*PR created automatically by Jules for task [5280212774496181012](https://jules.google.com/task/5280212774496181012) started by @truonglutienMaster*