### PR TITLE
Upgrade 'Ceramic White' visuals with PBR and Shadows

### DIFF
--- a/src/systems/SceneManager.js
+++ b/src/systems/SceneManager.js
@@ -27,6 +27,8 @@ export class SceneManager {
         // Renderer Setup
         this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas, antialias: true, alpha: true });
         this.renderer.setPixelRatio(window.devicePixelRatio);
+        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
         // Camera Setup
         this.camera3D = new THREE.PerspectiveCamera(40, 1, 1, 1000);
@@ -39,15 +41,20 @@ export class SceneManager {
         this.cameraTop.lookAt(0, 0, 0);
 
         // Lighting
-        const ambientLight = new THREE.AmbientLight(0x404040, 0.6);
+        const ambientLight = new THREE.AmbientLight(0x404040, 0.45); // Slightly reduced to deepen shadows
         this.scene.add(ambientLight);
 
-        const spotLight = new THREE.SpotLight(0xfff5e6, 1.0);
+        const spotLight = new THREE.SpotLight(0xfff5e6, 0.8);
         spotLight.position.set(100, 250, 100);
+        spotLight.castShadow = true;
+        spotLight.shadow.mapSize.width = 2048;
+        spotLight.shadow.mapSize.height = 2048;
+        spotLight.shadow.bias = -0.0001;
         this.scene.add(spotLight);
 
-        const dirLight = new THREE.DirectionalLight(0xd4d4d8, 0.4);
+        const dirLight = new THREE.DirectionalLight(0xd4d4d8, 0.5);
         dirLight.position.set(-100, 100, -50);
+        // Optional: castShadow on directional light if needed, but spotlight is main key
         this.scene.add(dirLight);
 
         // Object Group

--- a/src/utils/GeometryFactory.js
+++ b/src/utils/GeometryFactory.js
@@ -236,15 +236,25 @@ export function createModel(l, h, w, r, dX, dZ, hiddenSegments = {}, colorTheme 
     let colorBase, colorWall;
 
     if (colorTheme === 'white') {
-        colorBase = 0xD7CCC8;
+        // Increased contrast: darker, warmer taupe for base vs bright white wall
+        colorBase = 0xBCAAA4;
         colorWall = 0xFFFFFF;
     } else {
         colorBase = 0x4E342E;
         colorWall = 0x8D6E63;
     }
 
-    const matWall = new THREE.MeshPhongMaterial({ color: colorWall, shininess: 30, specular: 0x111111 });
-    const matBase = new THREE.MeshPhongMaterial({ color: colorBase, shininess: 30, specular: 0x111111 });
+    // Switch to StandardMaterial for PBR (Matte Ceramic look)
+    const matWall = new THREE.MeshStandardMaterial({
+        color: colorWall,
+        roughness: 0.7,
+        metalness: 0.1
+    });
+    const matBase = new THREE.MeshStandardMaterial({
+        color: colorBase,
+        roughness: 0.8,
+        metalness: 0.1
+    });
 
     const thick = 2;
     const outerShape = createRoundedRectShape(l, w, r);
@@ -324,6 +334,8 @@ export function createModel(l, h, w, r, dX, dZ, hiddenSegments = {}, colorTheme 
 
     const mesh = new THREE.Mesh(geo, matWall);
     mesh.position.y = -h/2 + h;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
 
     const baseShape = createRoundedRectShape(l, w, r);
     const baseGeo = new THREE.ExtrudeGeometry(baseShape, { depth: 2, bevelEnabled: false, curveSegments: 24 });
@@ -331,6 +343,7 @@ export function createModel(l, h, w, r, dX, dZ, hiddenSegments = {}, colorTheme 
 
     const base = new THREE.Mesh(baseGeo, matBase);
     base.position.y = -h/2 + 2;
+    base.receiveShadow = true;
 
     group.add(mesh);
     group.add(base);


### PR DESCRIPTION
Implemented visual improvements for the 'Ceramic White' theme as requested. Switched to PBR materials for a more realistic matte look, increased base color contrast, and enabled real-time shadow mapping to define the tray's volume.

---
*PR created automatically by Jules for task [5726369787286514633](https://jules.google.com/task/5726369787286514633) started by @truonglutienMaster*