### PR TITLE
feat: Apply 'Neutral High-Contrast' palette to Ceramic White theme

### DIFF
--- a/src/utils/GeometryFactory.js
+++ b/src/utils/GeometryFactory.js
@@ -236,9 +236,11 @@ export function createModel(l, h, w, r, dX, dZ, hiddenSegments = {}, colorTheme 
     let colorBase, colorWall;
 
     if (colorTheme === 'white') {
-        // Increased contrast: darker, warmer taupe for base vs bright white wall
-        colorBase = 0xBCAAA4;
-        colorWall = 0xFFFFFF;
+        // Neutral High-Contrast (User Request)
+        // Wall: Bright Gray #F5F5F7 (Reduces glare)
+        // Base: Deep Shadow #D2D2D7 (Separates bottom/wall)
+        colorBase = 0xD2D2D7;
+        colorWall = 0xF5F5F7;
     } else {
         colorBase = 0x4E342E;
         colorWall = 0x8D6E63;


### PR DESCRIPTION
- Updated 'Ceramic White' colors to Neutral High-Contrast palette as requested:
  - Wall: #F5F5F7 (Bright Gray/Off-white) to reduce glare.
  - Base: #D2D2D7 (Deep Shadow Gray) to define the boundary between bottom and walls.
- Retained PBR Material (Standard) and Shadow Mapping updates from previous step to ensure matte finish and volume definition.