### PR TITLE
Fix Ceramic White theme: remove cast shadows and adjust contrast

### DIFF
--- a/src/systems/SceneManager.js
+++ b/src/systems/SceneManager.js
@@ -41,12 +41,12 @@ export class SceneManager {
         this.cameraTop.lookAt(0, 0, 0);
 
         // Lighting
-        const ambientLight = new THREE.AmbientLight(0x404040, 0.45); // Slightly reduced to deepen shadows
+        const ambientLight = new THREE.AmbientLight(0x404040, 0.6); // Increased for softer look
         this.scene.add(ambientLight);
 
         const spotLight = new THREE.SpotLight(0xfff5e6, 0.8);
         spotLight.position.set(100, 250, 100);
-        spotLight.castShadow = true;
+        spotLight.castShadow = false; // Disabled to remove harsh black shadows per user feedback
         spotLight.shadow.mapSize.width = 2048;
         spotLight.shadow.mapSize.height = 2048;
         spotLight.shadow.bias = -0.0001;

--- a/src/utils/GeometryFactory.js
+++ b/src/utils/GeometryFactory.js
@@ -237,24 +237,24 @@ export function createModel(l, h, w, r, dX, dZ, hiddenSegments = {}, colorTheme 
 
     if (colorTheme === 'white') {
         // Neutral High-Contrast (User Request)
-        // Wall: Bright Gray #F5F5F7 (Reduces glare)
-        // Base: Deep Shadow #D2D2D7 (Separates bottom/wall)
-        colorBase = 0xD2D2D7;
+        // Wall: Neutral White #F5F5F7 (Reduces glare)
+        // Base: Light Grey #E0E0E0 (Distinct but bright)
+        colorBase = 0xE0E0E0;
         colorWall = 0xF5F5F7;
     } else {
         colorBase = 0x4E342E;
         colorWall = 0x8D6E63;
     }
 
-    // Switch to StandardMaterial for PBR (Matte Ceramic look)
+    // Switch to StandardMaterial for PBR (Ceramic look)
     const matWall = new THREE.MeshStandardMaterial({
         color: colorWall,
-        roughness: 0.7,
+        roughness: 0.5,
         metalness: 0.1
     });
     const matBase = new THREE.MeshStandardMaterial({
         color: colorBase,
-        roughness: 0.8,
+        roughness: 0.6,
         metalness: 0.1
     });
 


### PR DESCRIPTION
- Disable castShadow on SpotLight to remove harsh black shadows in Top View (user request).
- Increase AmbientLight intensity to 0.6 for softer lighting.
- Update Ceramic White theme colors: Wall to #F5F5F7 (Neutral White), Base to #E0E0E0 (Light Grey) for better contrast and visibility.
- Reduce material roughness (Wall 0.5, Base 0.6) for a slight ceramic sheen.