### PR TITLE
Temporarily hide Logo/Text section in sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
                 </div>
 
                 <!-- Logo / Text -->
-                <div>
+                <div class="hidden">
                     <div class="flex justify-between items-center mb-2">
                         <label class="text-xs text-zinc-400 font-bold uppercase tracking-wider">Engrave Text / Logo</label>
                     </div>


### PR DESCRIPTION
Added the 'hidden' class to the container div of the "Engrave Text / Logo" section in index.html to temporarily hide it from the UI as requested.

---
*PR created automatically by Jules for task [11593480974685373702](https://jules.google.com/task/11593480974685373702) started by @truonglutienMaster*