### PR TITLE
Move mobile view switcher to top-right

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,8 +156,8 @@
 
         <main id="viewports-container" class="w-full h-[45vh] shrink-0 md:h-auto md:flex-1 flex flex-col md:flex-row relative p-0 md:p-8 gap-0 md:gap-8 md:mr-[20%]">
 
-            <div class="absolute bottom-4 left-1/2 -translate-x-1/2 z-40 md:hidden pointer-events-auto">
-                <div class="bg-zinc-800/90 backdrop-blur-md p-1 rounded-xl flex gap-1 border border-white/10 shadow-lg scale-90">
+            <div class="absolute top-4 right-4 z-40 md:hidden pointer-events-auto">
+                <div class="bg-zinc-800/90 backdrop-blur-md p-1 rounded-xl flex gap-1 border border-white/10 shadow-lg scale-[0.8]">
                     <button id="tab-3d" class="px-5 py-2 rounded-lg text-xs font-bold transition-all bg-zinc-600 text-white shadow-sm">3D</button>
                     <button id="tab-top" class="px-5 py-2 rounded-lg text-xs font-bold transition-all text-zinc-400 hover:text-white">Top</button>
                 </div>


### PR DESCRIPTION
Moved the view switcher container in `index.html`:
- Removed `bottom-4`, `left-1/2`, `-translate-x-1/2`.
- Added `top-4`, `right-4`.
- Changed `scale-90` to `scale-[0.8]`.
- Verified position and appearance using a Playwright script.

---
*PR created automatically by Jules for task [8233807268298273893](https://jules.google.com/task/8233807268298273893) started by @truonglutienMaster*