### PR TITLE
Improve mobile slider usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
                         <label for="radius" class="text-xs text-zinc-400 font-bold uppercase tracking-wider">Corner Radius</label>
                         <span id="radius-val" class="text-xs text-white font-bold">8mm</span>
                     </div>
-                    <input type="range" id="radius" aria-label="Corner Radius" min="2" max="30" value="8" step="1">
+                    <input type="range" id="radius" class="w-[85%] mx-auto block" aria-label="Corner Radius" min="2" max="30" value="8" step="1">
                 </div>
 
                 <!-- Wall Thickness -->
@@ -216,7 +216,7 @@
                         <label for="wall-thickness" class="text-xs text-zinc-400 font-bold uppercase tracking-wider">Wall Thickness</label>
                         <span id="wall-thickness-val" class="text-xs text-white font-bold">2mm</span>
                     </div>
-                    <input type="range" id="wall-thickness" aria-label="Wall Thickness" min="2" max="10" value="2" step="0.5">
+                    <input type="range" id="wall-thickness" class="w-[85%] mx-auto block" aria-label="Wall Thickness" min="2" max="10" value="2" step="0.5">
                 </div>
 
                 <!-- Logo / Text -->


### PR DESCRIPTION
Modified the 'Corner Radius' and 'Wall Thickness' range inputs in `index.html` to be 85% width and centered (`mx-auto`). This prevents accidental edge gestures (like swiping to go back) on mobile devices when users try to interact with the sliders.

---
*PR created automatically by Jules for task [10345624417374241615](https://jules.google.com/task/10345624417374241615) started by @truonglutienMaster*