### PR TITLE
Fix mobile layout jump and stabilize input position

### DIFF
--- a/src/features/EditSystem.js
+++ b/src/features/EditSystem.js
@@ -39,19 +39,18 @@ export class EditSystem {
         this.current3DPos = worldPos3D;
 
         this.input.style.display = 'block';
-        this.input.style.left = `${x}px`;
-        this.input.style.top = `${y}px`;
         this.input.value = val;
 
-        // Mobile viewport lock
         if (window.innerWidth < 768) {
-            // Only lock if not already locked to prevent capturing compressed height during switches
-            if (!document.body.style.height) {
-                const h = window.innerHeight + 'px';
-                document.body.style.height = h;
-                document.documentElement.style.height = h;
-            }
-            // Canvas resize lock handled by store.isEditing check in resize listeners if implemented
+            // Mobile: Position input at top center to avoid keyboard occlusion and viewport jumping
+            // We ignore the passed x, y to ensure the input is always in the safe zone
+            this.input.style.left = '50%';
+            this.input.style.top = '15%'; // Safe zone near top
+            // Note: Global height locking is now handled in main.js, so we don't need to lock here.
+        } else {
+            // Desktop: Position at click target
+            this.input.style.left = `${x}px`;
+            this.input.style.top = `${y}px`;
         }
 
         this.input.focus();
@@ -85,6 +84,7 @@ export class EditSystem {
     }
 
     updatePosition(camera, rect3D) {
+        if (window.innerWidth < 768) return; // Mobile: Input is fixed at top, do not update with 3D projection
         if (!store.getState().isEditing || !this.current3DPos) return;
         if (rect3D.width === 0 || rect3D.height === 0) return;
 

--- a/src/main.js
+++ b/src/main.js
@@ -264,6 +264,39 @@ class App {
 }
 
 window.addEventListener('load', () => {
+    // Mobile Viewport Height Lock Logic
+    // Prevents interface jump when keyboard opens by setting a fixed pixel height on body
+    const fixMobileHeight = () => {
+        if (window.innerWidth < 768) {
+            // Only set height if not already set or if width changed (orientation change)
+            // We store the 'locked' width to detect true orientation changes vs keyboard resizes
+            const currentWidth = window.innerWidth;
+            const lastWidth = parseFloat(document.body.dataset.lastWidth || 0);
+
+            if (Math.abs(currentWidth - lastWidth) > 50) {
+                const h = window.innerHeight;
+                document.body.style.height = `${h}px`;
+                document.body.style.overflow = 'hidden'; // Ensure no scrolling on body
+                document.documentElement.style.height = `${h}px`;
+                document.documentElement.style.overflow = 'hidden';
+                document.body.dataset.lastWidth = currentWidth;
+            }
+        } else {
+             // Reset on desktop
+             document.body.style.height = '';
+             document.documentElement.style.height = '';
+             document.body.style.overflow = '';
+             document.documentElement.style.overflow = '';
+             delete document.body.dataset.lastWidth;
+        }
+    };
+
+    fixMobileHeight();
+    window.addEventListener('resize', () => {
+        // Debounce slightly to wait for layout settle? No, immediate is usually fine.
+        fixMobileHeight();
+    });
+
     window.app = new App();
     if (typeof lucide !== 'undefined') {
         lucide.createIcons();

--- a/verification/verify_mobile_fix_v2.py
+++ b/verification/verify_mobile_fix_v2.py
@@ -1,0 +1,49 @@
+from playwright.sync_api import sync_playwright
+
+def verify_mobile_fix_v2(page):
+    # Set mobile viewport (iPhone 12/13)
+    page.set_viewport_size({"width": 390, "height": 844})
+    page.goto("http://localhost:8000")
+
+    # 1. Verify Body Height Lock on Load
+    body_style = page.locator("body").get_attribute("style")
+    print(f"Initial Body Style: {body_style}")
+
+    # Check if height is set to pixel value (approx 844px)
+    if "height: 844px" in body_style or "height: 844" in body_style:
+        print("PASS: Body height locked on load")
+    else:
+        print("FAIL: Body height not locked on load")
+
+    # 2. Verify Input Position on Edit
+    # Wait for labels
+    page.wait_for_selector(".dim-label-3d", timeout=5000)
+    label = page.locator(".dim-label-3d").first
+
+    if label.count():
+        print("Clicking label to start edit...")
+        label.click()
+
+        # Check input visibility and position
+        input_el = page.locator("#global-dim-input")
+        input_style = input_el.get_attribute("style")
+        print(f"Input Style: {input_style}")
+
+        if "top: 15%" in input_style and "left: 50%" in input_style:
+            print("PASS: Input positioned at top safe zone")
+        else:
+             print("FAIL: Input not at top safe zone")
+
+    else:
+        print("FAIL: No 3D labels found")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        try:
+            verify_mobile_fix_v2(page)
+        except Exception as e:
+            print(f"Error: {e}")
+        finally:
+            browser.close()


### PR DESCRIPTION
- Implemented `fixMobileHeight` in `src/main.js` to lock `body` height on mobile, preventing layout squish when keyboard opens.
- Updated `src/features/EditSystem.js` to position the input field at a fixed safe zone (top center) on mobile, avoiding keyboard occlusion and viewport scrolling.
- Guarded `updatePosition` in `EditSystem` to prevent 3D projection updates from overriding the fixed mobile input position.
- Changed `#viewports-container` in `index.html` to use percentage height.