### PR TITLE
Fix STL export rotation for 3D printing alignment

### DIFF
--- a/src/features/ExportSystem.js
+++ b/src/features/ExportSystem.js
@@ -65,15 +65,15 @@ export class ExportSystem {
         const exporter = new THREE.STLExporter();
         const boxGroup = this.sceneManager.boxGroup;
 
-        // Reset rotation for export
-        const currentRotation = boxGroup.rotation.y;
-        boxGroup.rotation.y = 0;
+        // Rotate -90 degrees around X axis for export (Clockwise)
+        const currentRotX = boxGroup.rotation.x;
+        boxGroup.rotation.x -= Math.PI / 2;
         boxGroup.updateMatrixWorld();
 
         const result = exporter.parse(boxGroup, { binary: true });
 
         // Restore rotation
-        boxGroup.rotation.y = currentRotation;
+        boxGroup.rotation.x = currentRotX;
         boxGroup.updateMatrixWorld();
 
         const blob = new Blob([result], { type: 'application/octet-stream' });


### PR DESCRIPTION
This change updates the STL export logic to apply a -90 degree rotation around the X-axis (Clockwise) before exporting, which aligns the model correctly for 3D printing (flat Z-up orientation). It also removes the previous behavior of resetting the Y-axis rotation, preserving the user's view orientation logic during export (although the export view itself is temporary). This was done to fulfill the user's request to "rotate 90 degrees clockwise around X" and "remove the Y reset mechanism". Verification was performed using a mock script `verification/verify_export_rotation.mjs`.

---
*PR created automatically by Jules for task [77519461274022962](https://jules.google.com/task/77519461274022962) started by @truonglutienMaster*