### PR TITLE
Fix initial tutorial synchronization

### DIFF
--- a/src/features/TutorialSystem.js
+++ b/src/features/TutorialSystem.js
@@ -22,13 +22,14 @@ export class TutorialSystem {
         this.ghostDivider = document.getElementById('ghost-divider');
         this.cursorTrail = document.getElementById('cursor-trail');
 
+        this.pendingStart = false;
         this.bindEvents();
         this.init();
     }
 
     init() {
         if (!sessionStorage.getItem('tutorial_seen')) {
-            this.start();
+            this.pendingStart = true;
             sessionStorage.setItem('tutorial_seen', 'true');
         } else {
             if (this.skipBtn) this.skipBtn.innerText = "Tutorial";
@@ -41,6 +42,14 @@ export class TutorialSystem {
         if (this.skipBtn) {
             this.skipBtn.addEventListener('click', () => this.toggle());
         }
+
+        // Start tutorial only after the model is generated and everything is ready for the first time
+        store.on('modelRegenerated', () => {
+            if (this.pendingStart) {
+                this.pendingStart = false;
+                this.start();
+            }
+        });
 
         // Subscribe to Store events to advance steps automatically
         store.on('dimensionsChanged', () => {


### PR DESCRIPTION
Fixes the issue where the first step of the tutorial points to the wrong location on the first load because the 3D model hasn't completely rendered its labels. Replaces the direct initial call to `start()` with an event-driven hook waiting for `store.on('modelRegenerated')`.

---
*PR created automatically by Jules for task [17205642035450080654](https://jules.google.com/task/17205642035450080654) started by @truonglutienMaster*