### PR TITLE
fix(mobile): prevent keyboard scroll jump and fix auto-zoom on dimens…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-visual">
     <title>Parameterized Tray - Pro Segment Designer</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
@@ -179,7 +179,7 @@
         </main>
 
         <aside class="relative z-50 bg-[#1e1e1e] border-t md:border-t-0 md:border-l border-white/10 flex flex-col
-                      w-full flex-1 rounded-t-3xl md:rounded-none
+                      w-full flex-1 md:rounded-t-3xl md:rounded-none
                       md:fixed md:top-0 md:right-0 md:w-1/5 md:h-full
                       overflow-hidden transition-all duration-300 pointer-events-auto
                       shadow-[0_-4px_30px_rgba(0,0,0,0.6)] md:shadow-none shrink-0">

--- a/src/features/EditSystem.js
+++ b/src/features/EditSystem.js
@@ -7,6 +7,8 @@ export class EditSystem {
         this.input = document.getElementById('global-dim-input');
         this.currentCallback = null;
         this.current3DPos = null;
+        this._scrollLockListener = null;
+        this._keyboardSettled = false;
 
         this.bindEvents();
     }
@@ -37,6 +39,7 @@ export class EditSystem {
         store.setEditing(true);
         this.currentCallback = cb;
         this.current3DPos = worldPos3D;
+        this._keyboardSettled = false;
 
         this.input.style.display = 'block';
         this.input.value = val;
@@ -45,8 +48,52 @@ export class EditSystem {
         this.input.style.left = `${x}px`;
         this.input.style.top = `${y}px`;
 
-        this.input.focus();
+        // PRIMARY FIX: preventScroll tells the browser NOT to scroll
+        // the page to bring the input into view -- eliminates the jump
+        this.input.focus({ preventScroll: true });
         this.input.select();
+
+        // SECONDARY FIX: lock body scroll for iOS Safari
+        this._lockScroll();
+        // Allow 3D position updates only after keyboard has fully animated in
+        setTimeout(() => { this._keyboardSettled = true; }, 500);
+    }
+
+    _lockScroll() {
+        // Fix body to prevent iOS Safari rubber-band scrolling
+        const scrollY = window.scrollY;
+        document.body.style.position = 'fixed';
+        document.body.style.top = `-${scrollY}px`;
+        document.body.style.left = '0';
+        document.body.style.right = '0';
+        this._savedScrollY = scrollY;
+
+        // Fallback: instant scrollTo (no animation) in case any scroll slips through
+        const lock = () => window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+        lock();
+        this._scrollLockListener = lock;
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', lock);
+            window.visualViewport.addEventListener('scroll', lock);
+        }
+    }
+
+    _unlockScroll() {
+        // Restore body scroll position (undo the position:fixed trick)
+        document.body.style.position = '';
+        document.body.style.top = '';
+        document.body.style.left = '';
+        document.body.style.right = '';
+        if (this._savedScrollY !== undefined) {
+            window.scrollTo({ top: this._savedScrollY, left: 0, behavior: 'instant' });
+            this._savedScrollY = undefined;
+        }
+
+        if (this._scrollLockListener && window.visualViewport) {
+            window.visualViewport.removeEventListener('resize', this._scrollLockListener);
+            window.visualViewport.removeEventListener('scroll', this._scrollLockListener);
+        }
+        this._scrollLockListener = null;
     }
 
     finishEditing() {
@@ -68,6 +115,8 @@ export class EditSystem {
     cleanup() {
         store.setEditing(false);
         this.current3DPos = null;
+        this._keyboardSettled = false;
+        this._unlockScroll();
         this.input.style.display = 'none';
         this.currentCallback = null;
     }
@@ -75,6 +124,8 @@ export class EditSystem {
     updatePosition(camera, rect3D) {
         if (!store.getState().isEditing || !this.current3DPos) return;
         if (rect3D.width === 0 || rect3D.height === 0) return;
+        // Don't reposition while keyboard is still animating open (avoids jitter)
+        if (!this._keyboardSettled) return;
 
         const vector = new THREE.Vector3(this.current3DPos.x, this.current3DPos.y, this.current3DPos.z);
 

--- a/src/systems/SceneManager.js
+++ b/src/systems/SceneManager.js
@@ -92,7 +92,15 @@ export class SceneManager {
         const labelPadding = 60; // Padding for labels
 
         // Fit Top View
-        const rectTop = this.viewTopContainer.getBoundingClientRect();
+        let rectTop = this.viewTopContainer.getBoundingClientRect();
+
+        // On mobile (tab=3D), top view is hidden → height=0.
+        // Fall back to the 3D container's rect so we can still calculate a valid frustum.
+        const rectFallback = this.view3DContainer.getBoundingClientRect();
+        if (rectTop.height === 0 && rectFallback.height > 0) {
+            rectTop = rectFallback;
+        }
+
         if (rectTop.height > 0) {
             const aspect = rectTop.width / rectTop.height;
             this.frustumSize = Math.max(w + labelPadding, (l + labelPadding) / aspect) * 1.4;


### PR DESCRIPTION
…ion edit

- index.html: add interactive-widget=resizes-visual to viewport meta to prevent Chrome Android from scrolling layout when soft keyboard opens; remove rounded top corners (rounded-t-3xl) from aside panel on mobile viewports

- EditSystem.js: use focus({ preventScroll: true }) as primary fix to stop browser scrolling to input on focus; add body position:fixed trick for iOS Safari; add instant visualViewport scroll lock as fallback; add _keyboardSettled guard to pause 3D label updatePosition() for 500ms while keyboard animates in

- SceneManager.js: fix autoFitCamera() to use 3D container rect as fallback when top-view is hidden (height=0 on mobile tab=3D), ensuring camera and frustum update immediately after dimension changes without requiring a tab switch